### PR TITLE
[DRAFT] Added WezTerm Neon config for initial review

### DIFF
--- a/extras/wezterm/silkcircuit-neon.lua
+++ b/extras/wezterm/silkcircuit-neon.lua
@@ -1,0 +1,36 @@
+local silkcircuit = {
+  foreground = "#FBF5F3",
+  background = "#14111F",
+
+  cursor_bg = "#e135ff",
+  cursor_fg = "#14111F",
+  cursor_border = "#e135ff",
+
+  selection_bg = "#44475a",
+  selection_fg = "#FBF5F3",
+
+  ansi = {
+    "#14111F",
+    "#ff79c6",
+    "#50fa7b",
+    "#f1fa8c",
+    "#bd93f9",
+    "#e135ff",
+    "#80ffea",
+    "#FBF5F3",
+  },
+
+  brights = {
+    "#6272a4",
+    "#ff5555",
+    "#50fa7b",
+    "#f1fa8c",
+    "#bd93f9",
+    "#ff79c6",
+    "#5fffff",
+    "#ffffff",
+  },
+}
+
+return silkcircuit
+


### PR DESCRIPTION
Hi, huge fan of SilkCircuit! As a daily WezTerm user, noticed that WezTerm was missing SilkCircuit themes. Whipped this draft PR up using my local WezTerm config (only included neon for now), and it's been working fine for me over the past few days. If this looks okay, I can implement colors over the other SilkCircuit variants as well!