### PR TITLE
chore: name the next release 2.0.0

### DIFF
--- a/lua/silkcircuit/extra/vscode.lua
+++ b/lua/silkcircuit/extra/vscode.lua
@@ -10,9 +10,10 @@
 local M = {}
 
 -- Roles no single palette key can serve in both a dark and a light theme.
--- Dawn's cyan and coral are mixed to sit on a near-white page, so they read at
--- 2.8:1 and 4.2:1 as ink there and cannot carry the accents that work on the
--- dark variants. Each falls back to a purple or pink that clears 4.5:1.
+-- The palette retune brought dawn's cyan and coral above 5.4:1 as ink, so
+-- the light fallbacks below are no longer about contrast: they keep dawn's
+-- accents in the purple and pink family the light theme is built around,
+-- where a cyan focus ring would read as a different brand.
 --
 --   shadow        has to darken whatever sits under it
 --   accent_border focus rings, active indicators, section headers: the cyan


### PR DESCRIPTION
A real commit carrying the Release-As footer, since the rebase merge of #8 silently dropped the empty one (git rebase discards empty commits). It rides along with a comment fix in vscode.lua that still cited pre-retune contrast numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtDjeCyHdLUr9R4XnnFVx9