### PR TITLE
docs: catch the prose up with v2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,13 @@
 
 ## Project Overview
 
-SilkCircuit is a unified design system featuring neon purples, electric pinks, and glowing cyan accents. It themes your entire dev environment: Neovim (the flagship, with 25+ plugin integrations), VS Code, Chrome, terminals, and 20+ CLI and system tools. The project prioritizes performance, WCAG AA accessibility, and a consistent visual identity across all targets.
+SilkCircuit is a unified design system featuring neon purples, electric pinks, and glowing cyan accents. It themes your entire dev environment: Neovim is the flagship, with 39 plugin integrations, and 30 generated extras targets cover VS Code, Chrome, terminals, editors, multiplexers, and CLI and system tools. The project prioritizes performance, WCAG AA accessibility, and a consistent visual identity across all targets.
 
 ## Core Principles
 
 1. **Performance First** - Theme loads in a few milliseconds with every integration defined
 2. **Accessibility** - All colors meet WCAG AA contrast standards
-3. **Plugin Auto-Detection** - Automatically detect and theme installed plugins
+3. **Passive loading** - Every integration is defined up front; detection only informs `:SilkCircuitIntegrations` and `:checkhealth`
 4. **User Choice** - Five variants (neon/vibrant/soft/glow/dawn) with persistent preferences
 
 ## Code Style Guidelines
@@ -53,13 +53,13 @@ return M
 - `palette.lua` - Color definitions and semantic mappings
 - `theme.lua` - Core highlight group definitions
 - `config.lua` - Configuration management
-- `util.lua` - Utility functions and compilation
+- `util.lua` - Highlight application and style merging
 - `utils/colors.lua` - Color math: blending, contrast ratios, variant scaling
 - `health.lua` - `:checkhealth silkcircuit` provider
 
 ### Integration System
 
-- `integrations/init.lua` - Plugin detection and loading
+- `integrations/init.lua` - The integration registry, plus loading and reporting
 - `integrations/{plugin}.lua` - Individual plugin themes
 
 ### User Features
@@ -79,9 +79,9 @@ return M
 ### New Integration
 
 1. Create `integrations/{plugin}.lua`
-2. Add to detection in `integrations/init.lua`
-3. Add to integration list
-4. Test with and without plugin
+2. Add to the registry in `integrations/init.lua`, with the `modules` and `plugin` names detection reports on
+3. Add its key to the `integrations` defaults in `config.lua`
+4. Test with and without the plugin installed; the highlights load either way
 
 Template:
 
@@ -220,7 +220,7 @@ Examples:
 
 - `fix: correct YAML key highlighting`
 - `feat: add mason.nvim integration`
-- `perf: optimize theme compilation`
+- `perf: skip disabled integrations in the load loop`
 
 ### Pull Requests
 
@@ -237,7 +237,7 @@ changelog entry users read.
 ### Common Issues
 
 1. **Highlights not applying**: Check `:hi {GroupName}`
-2. **Plugin not detected**: Verify in `:SilkCircuitIntegrations`
+2. **Plugin looks unthemed**: Confirm its key is not set to `false` in `setup()`, then check `:SilkCircuitIntegrations`
 3. **Colors look wrong**: Check terminal true color support
 
 ### Debug Mode
@@ -262,7 +262,7 @@ vim.g.silkcircuit_debug = true
 - `:SilkCircuit {variant}` - Switch variant
 - `:SilkCircuitGlow` - Toggle glow mode
 - `:SilkCircuitContrast` - Check WCAG compliance
-- `:SilkCircuitIntegrations` - Show detected plugins
+- `:SilkCircuitIntegrations` - Show integration status
 - `:checkhealth silkcircuit` - Full diagnostics
 
 ### File Locations

--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ One palette, one semantic system, five intensity variants, every tool in your wo
 
 ### 🌐 Platforms
 
-| Category         | Targets                                                           |
-| ---------------- | ----------------------------------------------------------------- |
-| 💻 **Editors**   | Neovim (39 plugin integrations), VS Code (Marketplace), AstroNvim |
-| 🖥️ **Terminals** | Ghostty, Kitty, Alacritty, Warp, Windows Terminal                 |
-| 🌐 **Browsers**  | Chrome (Web Store, 5 variants + DevTools CSS)                     |
-| 🔧 **CLI Tools** | btop, K9s, lazygit, bat, fzf, lsd, procs, atuin, Starship         |
-| ⚙️ **System**    | COSMIC Desktop, fastfetch, dmesg, tmux                            |
-| 🎯 **Other**     | Git (delta integration), Slack, Lualine                           |
+| Category            | Targets                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| 💻 **Editors**      | Neovim (39 plugin integrations), VS Code (Marketplace), AstroNvim, Helix |
+| 🖥️ **Terminals**    | Ghostty, Kitty, Alacritty, WezTerm, foot, iTerm2, Warp, Windows Terminal |
+| 🪟 **Multiplexers** | tmux, Zellij                                                             |
+| 🌐 **Browsers**     | Chrome (Web Store, 5 variants + DevTools CSS)                            |
+| 🔧 **CLI Tools**    | btop, K9s, lazygit, bat, fzf, lsd, procs, atuin, Starship                |
+| ⚙️ **System**       | COSMIC Desktop, fastfetch, dmesg                                         |
+| 🎯 **Other**        | Git (delta integration), Slack, Lualine                                  |
 
 ### 🎛️ Variants
 
@@ -231,7 +232,7 @@ Copy-Item extras\starship\silkcircuit-neon.toml "$HOME\.config\starship.toml"
 
 ## 💜 Neovim
 
-The Neovim theme is the most feature-rich target: it loads in about 5ms with every one of its 29 plugin integrations defined up front, and it remembers your variant across sessions.
+The Neovim theme is the most feature-rich target: it loads in about 5ms with every one of its 39 plugin integrations defined up front, and it remembers your variant across sessions.
 
 <div align="center">
   <img src="assets/screenshots/nvim-telescope.png" alt="Telescope integration" width="85%">
@@ -298,16 +299,19 @@ SilkCircuit extends far beyond your editor. The [extras guide](https://hyperb1is
 
 ### 🎨 Color Palette
 
+The neon variant's core roles. The other four remap the same roles to their own values, listed on the [variant pages](https://hyperb1iss.github.io/silkcircuit/variants/).
+
 | Color              | Hex       | Usage                                                                              |
 | ------------------ | --------- | ---------------------------------------------------------------------------------- |
-| Background         | `#0a0a0f` | ![#0a0a0f](https://placehold.co/20x20/0a0a0f/0a0a0f.png)                           |
-| Foreground         | `#e0e0e0` | ![#e0e0e0](https://placehold.co/20x20/e0e0e0/e0e0e0.png)                           |
+| Background         | `#12101a` | ![#12101a](https://placehold.co/20x20/12101a/12101a.png)                           |
+| Foreground         | `#f8f8f2` | ![#f8f8f2](https://placehold.co/20x20/f8f8f2/f8f8f2.png)                           |
 | 💜 Electric Purple | `#e135ff` | ![#e135ff](https://placehold.co/20x20/e135ff/e135ff.png) Keywords, primary accents |
-| 🌸 Hot Pink        | `#ff79c6` | ![#ff79c6](https://placehold.co/20x20/ff79c6/ff79c6.png) Strings, secondary        |
+| 🌸 Soft Pink       | `#ff99ff` | ![#ff99ff](https://placehold.co/20x20/ff99ff/ff99ff.png) Strings                   |
 | 💎 Neon Cyan       | `#80ffea` | ![#80ffea](https://placehold.co/20x20/80ffea/80ffea.png) Functions, links          |
-| ✅ Success Green   | `#50fa7b` | ![#50fa7b](https://placehold.co/20x20/50fa7b/50fa7b.png) Success states            |
-| ⚡ Electric Yellow | `#f1fa8c` | ![#f1fa8c](https://placehold.co/20x20/f1fa8c/f1fa8c.png) Warnings, variables       |
-| 🧡 Warm Orange     | `#ffb86c` | ![#ffb86c](https://placehold.co/20x20/ffb86c/ffb86c.png) Numbers, constants        |
+| 🌺 Hot Coral       | `#ff6ac1` | ![#ff6ac1](https://placehold.co/20x20/ff6ac1/ff6ac1.png) Numbers, constants        |
+| ⚡ Electric Yellow | `#f1fa8c` | ![#f1fa8c](https://placehold.co/20x20/f1fa8c/f1fa8c.png) Classes, types            |
+| ✅ Success Green   | `#50fa7b` | ![#50fa7b](https://placehold.co/20x20/50fa7b/50fa7b.png) Success, git additions    |
+| ❌ Error Red       | `#ff6363` | ![#ff6363](https://placehold.co/20x20/ff6363/ff6363.png) Errors, git deletions     |
 
 ## 📸 Screenshot Gallery
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ require("silkcircuit").setup({
   },
 
   integrations = {
-    telescope = true,     -- all auto-detected by default
+    telescope = true,     -- all 39 ship enabled; set one false to skip it
     neotree = true,
     notify = true,
     cmp = true,
@@ -266,7 +266,7 @@ require("silkcircuit").setup({
 
 ### 🔮 Plugin Support
 
-All integrations activate automatically when plugins are detected.
+All 39 integrations are defined up front, whether or not the plugin is installed, so nothing waits on detection. Turn one off with `integrations.<name> = false`.
 
 - 🎯 **Core**: Telescope, Neo-tree, LSP, Treesitter, nvim-cmp, Mason
 - 🏃 **Navigation**: Flash, Harpoon, Which-Key, Mini.jump

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -153,19 +153,19 @@ SilkCircuit uses five carefully crafted variants, each with precisely tuned colo
 
 ### Universal Supporting Colors
 
-**Success Green** (`#50fa7b` / Soft: `#66ff99` / Glow: `#00ff00` / Dawn: `#1d6e46`)
+**Success Green** (`#50fa7b` / Vibrant: `#00ff66` / Soft: `#66ff99` / Glow: `#00ff00` / Dawn: `#1d6e46`)
 
 - Success states, git additions, confirmations
 - Semantic: Growth, positive actions, validation
 - Applications: Success messages, add buttons, valid states
 
-**Warning Yellow** (`#f1fa8c` / Soft: `#ffe699` / Glow: `#ffff00` / Dawn: `#796100`)
+**Warning Yellow** (`#f1fa8c` / Vibrant: `#ffcc00` / Soft: `#ffe699` / Glow: `#ffff00` / Dawn: `#796100`)
 
 - Caution, attention, modification
 - Semantic: Alert, change, pending
 - Applications: Warning messages, modified indicators
 
-**Error Red** (`#ff6363` / Soft: `#ff6677` / Glow: `#ff2244` / Dawn: `#c1272d`)
+**Error Red** (`#ff6363` / Vibrant: `#ff3366` / Soft: `#ff6677` / Glow: `#ff2244` / Dawn: `#c1272d`)
 
 - Errors, deletions, danger
 - Semantic: Stop, danger, removal

--- a/doc/silkcircuit.txt
+++ b/doc/silkcircuit.txt
@@ -24,7 +24,7 @@ CONTENTS                                            *silkcircuit-contents*
 1. INTRODUCTION                                     *silkcircuit-introduction*
 
 SilkCircuit is a Neovim colorscheme built on electric purples, hot pinks and
-glowing cyan. It ships five variants, themes 29 plugins, and persists your
+glowing cyan. It ships five variants, themes 39 plugins, and persists your
 variant and glow-mode choices between sessions.
 
 Highlights are defined for every enabled integration whether or not the

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress';
 
 export default defineConfig({
   title: 'SilkCircuit',
-  description: 'A vibrant cyberpunk color system for Neovim, VS Code, terminals, browsers, and 20+ CLI tools',
+  description: 'A vibrant cyberpunk color system for Neovim, VS Code, terminals, browsers, and 30 CLI tools',
 
   base: '/silkcircuit/',
 
@@ -11,7 +11,7 @@ export default defineConfig({
     ['meta', { name: 'theme-color', content: '#e135ff' }],
     ['meta', { name: 'og:type', content: 'website' }],
     ['meta', { name: 'og:title', content: 'SilkCircuit - Electric Meets Elegant' }],
-    ['meta', { name: 'og:description', content: 'A vibrant cyberpunk color system for Neovim, VS Code, terminals, browsers, and 20+ CLI tools. WCAG AA compliant with 5 variants.' }],
+    ['meta', { name: 'og:description', content: 'A vibrant cyberpunk color system for Neovim, VS Code, terminals, browsers, and 30 CLI tools. WCAG AA compliant with 5 variants.' }],
     ['meta', { name: 'og:image', content: '/silkcircuit/og-image.png' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
   ],

--- a/docs/design/accessibility.md
+++ b/docs/design/accessibility.md
@@ -4,14 +4,16 @@ SilkCircuit is designed with accessibility as a core principle.
 
 ## WCAG AA Compliance
 
-All SilkCircuit color combinations meet or exceed WCAG AA standards:
+Contrast is measured rather than asserted. The test suite computes every ratio from the WCAG formula and fails if any pair falls under its bar, and `:checkhealth silkcircuit` reports the text numbers for whichever variant you are running.
 
-| Criterion          | Requirement   | SilkCircuit |
-| ------------------ | ------------- | ----------- |
-| Normal text        | 4.5:1 minimum | Verified    |
-| Large text (18pt+) | 3:1 minimum   | Verified    |
-| UI elements        | 3:1 minimum   | Verified    |
-| Graphics           | 3:1 minimum   | Verified    |
+| Criterion          | Requirement   | SilkCircuit                                                               |
+| ------------------ | ------------- | ------------------------------------------------------------------------- |
+| Normal text        | 4.5:1 minimum | Gated for every text color on the page, the float body and the cursorline |
+| Large text (18pt+) | 3:1 minimum   | Covered by the stricter 4.5:1 text bar                                    |
+| UI elements        | 3:1 minimum   | Gated for borders, gutters, indent guides and the ANSI normals            |
+| Graphics           | 3:1 minimum   | A design target, not machine-checked                                      |
+
+`:checkhealth silkcircuit` runs the narrower version of the text check, measuring each distinct text color against the active variant's own background. On neon it reports 19 colors checked and no issues.
 
 ## Variant Accessibility
 

--- a/docs/design/best-practices.md
+++ b/docs/design/best-practices.md
@@ -22,10 +22,7 @@ Every color should carry the same meaning across your entire application.
 
 Never sacrifice accessibility for aesthetics.
 
-```css
-/* Test all color combinations */
-:silkcircuitcontrast;
-```
+In Neovim, `:SilkCircuitContrast` measures every text color against the active variant's background and reports anything under 4.5:1.
 
 ### Apply glow effects sparingly
 

--- a/docs/design/colors.md
+++ b/docs/design/colors.md
@@ -125,30 +125,33 @@ These colors maintain semantic meaning across all variants:
 
 ### Success
 
-| Variant      | Hex       | Usage                   |
-| ------------ | --------- | ----------------------- |
-| Neon/Vibrant | `#50fa7b` | Git add, success states |
-| Soft         | `#66ff99` | Git add, success states |
-| Glow         | `#00ff00` | Git add, success states |
-| Dawn         | `#1d6e46` | Git add, success states |
+| Variant | Hex       | Usage                   |
+| ------- | --------- | ----------------------- |
+| Neon    | `#50fa7b` | Git add, success states |
+| Vibrant | `#00ff66` | Git add, success states |
+| Soft    | `#66ff99` | Git add, success states |
+| Glow    | `#00ff00` | Git add, success states |
+| Dawn    | `#1d6e46` | Git add, success states |
 
 ### Warning
 
-| Variant      | Hex       | Usage             |
-| ------------ | --------- | ----------------- |
-| Neon/Vibrant | `#f1fa8c` | Caution, modified |
-| Soft         | `#ffe699` | Caution, modified |
-| Glow         | `#ffff00` | Caution, modified |
-| Dawn         | `#796100` | Caution, modified |
+| Variant | Hex       | Usage             |
+| ------- | --------- | ----------------- |
+| Neon    | `#f1fa8c` | Caution, modified |
+| Vibrant | `#ffcc00` | Caution, modified |
+| Soft    | `#ffe699` | Caution, modified |
+| Glow    | `#ffff00` | Caution, modified |
+| Dawn    | `#796100` | Caution, modified |
 
 ### Error
 
-| Variant      | Hex       | Usage             |
-| ------------ | --------- | ----------------- |
-| Neon/Vibrant | `#ff6363` | Errors, deletions |
-| Soft         | `#ff6677` | Errors, deletions |
-| Glow         | `#ff2244` | Errors, deletions |
-| Dawn         | `#c1272d` | Errors, deletions |
+| Variant | Hex       | Usage             |
+| ------- | --------- | ----------------- |
+| Neon    | `#ff6363` | Errors, deletions |
+| Vibrant | `#ff3366` | Errors, deletions |
+| Soft    | `#ff6677` | Errors, deletions |
+| Glow    | `#ff2244` | Errors, deletions |
+| Dawn    | `#c1272d` | Errors, deletions |
 
 ## Interactive States
 

--- a/docs/design/semantic.md
+++ b/docs/design/semantic.md
@@ -142,7 +142,7 @@ require("silkcircuit").setup({
     hl.Number = { fg = colors.coral }
     hl.Boolean = { fg = colors.pink }
     hl.Type = { fg = colors.yellow }
-    hl.Comment = { fg = colors.gray, italic = true }
+    hl.Comment = { fg = colors.comment, italic = true }
   end,
 })
 ```

--- a/docs/design/semantic.md
+++ b/docs/design/semantic.md
@@ -125,7 +125,7 @@ end
 
 2. **Maintain across variants**: The meaning stays constant; only intensity changes.
 
-3. **Apply to plugins**: All 35+ integrations follow the same color semantics.
+3. **Apply to plugins**: All 39 integrations follow the same color semantics.
 
 4. **Extend thoughtfully**: New elements should map to existing semantic colors.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -112,7 +112,7 @@ require("silkcircuit").setup({
   on_highlights = function(highlights, colors)
     -- Use theme colors
     highlights.Function = { fg = colors.cyan, bold = true }
-    highlights.Comment = { fg = colors.gray, italic = true }
+    highlights.Comment = { fg = colors.comment, italic = true }
 
     -- Or custom colors
     highlights.MyCustomGroup = { fg = "#ff00ff", bg = "#000000" }
@@ -134,7 +134,8 @@ The `colors` table includes:
 | `yellow`    | Classes, types         |
 | `green`     | Success, git add       |
 | `red`       | Errors, git delete     |
-| `gray`      | Comments, muted text   |
+| `gray`      | Line numbers, glyphs   |
+| `comment`   | Comments (purple)      |
 | `bg`        | Background             |
 | `fg`        | Foreground             |
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -91,17 +91,17 @@ Enable or disable specific plugin integrations:
 ```lua
 require("silkcircuit").setup({
   integrations = {
-    telescope = true,    -- Telescope (auto-detected)
-    neotree = true,      -- Neo-tree (auto-detected)
-    notify = true,       -- nvim-notify (auto-detected)
-    cmp = true,          -- nvim-cmp (auto-detected)
-    mini = true,         -- mini.nvim (auto-detected)
+    telescope = true,    -- Telescope
+    neotree = true,      -- Neo-tree
+    notify = true,       -- nvim-notify
+    cmp = true,          -- nvim-cmp
+    mini = true,         -- mini.nvim
     -- See :h silkcircuit-integrations for full list
   },
 })
 ```
 
-Most integrations are auto-detected. You only need to configure them if you want to disable one.
+All 39 integrations ship enabled and their highlights load whether or not the plugin is installed, so the only reason to touch this table is to turn one off. The newer keys are `blink_cmp`, `fzf_lua`, `oil`, `trouble`, `lazy`, `grug_far`, `treesitter_context`, `fidget`, `neotest`, and `dropbar`; see `:h silkcircuit-integrations` for the full list.
 
 ## Custom Highlights
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -6,7 +6,7 @@ SilkCircuit is a unified color system for your entire development environment. O
 
 ### Electric Meets Elegant
 
-SilkCircuit themes 20+ tools with the same palette and semantic mappings. Keywords are always purple, functions are always cyan, strings are always pink, whether you're in Neovim, VS Code, or reading a diff in your terminal.
+SilkCircuit themes 30 tools with the same palette and semantic mappings. Keywords are always purple, functions are always cyan, strings are always pink, whether you're in Neovim, VS Code, or reading a diff in your terminal.
 
 ### Performance First
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -28,7 +28,7 @@ All color combinations meet WCAG AA standards (4.5:1 contrast ratio minimum). Co
 
 ## Features at a Glance
 
-- 🎨 **35+ Plugin Integrations**: Auto-detected and themed
+- 🎨 **39 Plugin Integrations**: Defined up front, installed or not
 - 🏎️ **~5ms Load Time**: No cache, nothing to regenerate
 - 👁️ **WCAG AA Compliant**: Validated contrast ratios
 - 💾 **Persistent Preferences**: Settings survive across sessions

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: SilkCircuit
   text: Electric Meets Elegant
-  tagline: A vibrant cyberpunk color system for Neovim, VS Code, terminals, browsers, and 20+ tools
+  tagline: A vibrant cyberpunk color system for Neovim, VS Code, terminals, browsers, and 30 tools
   image:
     src: /logo.png
     alt: SilkCircuit
@@ -21,7 +21,7 @@ features:
     title: 5 Electric Variants
     details: Neon, Vibrant, Soft, Glow, and Dawn - from maximum intensity dark themes to a beautiful light mode
   - icon: 🎨
-    title: 35+ Plugin Integrations
+    title: 39 Plugin Integrations
     details: Telescope, Neo-tree, LSP, nvim-cmp, and your entire toolchain, all defined up front
   - icon: 👁️
     title: WCAG AA Compliant

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,13 +22,13 @@ features:
     details: Neon, Vibrant, Soft, Glow, and Dawn - from maximum intensity dark themes to a beautiful light mode
   - icon: 🎨
     title: 35+ Plugin Integrations
-    details: Auto-detected support for Telescope, Neo-tree, LSP, nvim-cmp, and your entire toolchain
+    details: Telescope, Neo-tree, LSP, nvim-cmp, and your entire toolchain, all defined up front
   - icon: 👁️
     title: WCAG AA Compliant
     details: Every color combination validated for accessibility with 4.5:1+ contrast ratios
   - icon: 🏎️
-    title: <5ms Load Time
-    details: Bytecode compilation with intelligent caching for instant theme loading
+    title: "~5ms Load Time"
+    details: Loads in about 5ms with every integration defined up front. No cache to regenerate, nothing to warm.
   - icon: 🌈
     title: Semantic Colors
     details: Consistent color meanings across all languages and plugins for intuitive coding

--- a/docs/reference/colors.md
+++ b/docs/reference/colors.md
@@ -33,7 +33,7 @@ Complete color palette for all SilkCircuit variants.
 | Success | `#50fa7b` | `#66ff99` | `#00ff00` | `#1d6e46` |
 | Warning | `#f1fa8c` | `#ffe699` | `#ffff00` | `#796100` |
 | Error   | `#ff6363` | `#ff6677` | `#ff2244` | `#c1272d` |
-| Info    | `#82AAFF` | `#92aaff` | `#0099ff` | `#1454dc` |
+| Info    | `#82aaff` | `#92aaff` | `#0099ff` | `#1454dc` |
 
 ## Neon Palette
 
@@ -62,7 +62,7 @@ yellow = "#f1fa8c"
 -- Supporting
 green = "#50fa7b"
 red = "#ff6363"
-blue = "#82AAFF"
+blue = "#82aaff"
 gray = "#768d8d"
 ```
 

--- a/docs/reference/colors.md
+++ b/docs/reference/colors.md
@@ -28,12 +28,12 @@ Complete color palette for all SilkCircuit variants.
 
 ### Status Colors
 
-| Status  | Neon      | Soft      | Glow      | Dawn      |
-| ------- | --------- | --------- | --------- | --------- |
-| Success | `#50fa7b` | `#66ff99` | `#00ff00` | `#1d6e46` |
-| Warning | `#f1fa8c` | `#ffe699` | `#ffff00` | `#796100` |
-| Error   | `#ff6363` | `#ff6677` | `#ff2244` | `#c1272d` |
-| Info    | `#82aaff` | `#92aaff` | `#0099ff` | `#1454dc` |
+| Status  | Neon      | Vibrant   | Soft      | Glow      | Dawn      |
+| ------- | --------- | --------- | --------- | --------- | --------- |
+| Success | `#50fa7b` | `#00ff66` | `#66ff99` | `#00ff00` | `#1d6e46` |
+| Warning | `#f1fa8c` | `#ffcc00` | `#ffe699` | `#ffff00` | `#796100` |
+| Error   | `#ff6363` | `#ff3366` | `#ff6677` | `#ff2244` | `#c1272d` |
+| Info    | `#82aaff` | `#6699ff` | `#92aaff` | `#0099ff` | `#1454dc` |
 
 ## Neon Palette
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -41,7 +41,7 @@ Toggle glow mode for enhanced visual effects.
 :SilkCircuitGlow
 ```
 
-Glow mode adds subtle text shadows and enhanced highlighting to syntax elements.
+Glow mode brightens functions, keywords, strings, types and float borders on top of the current variant.
 
 ---
 
@@ -53,7 +53,7 @@ Validate WCAG contrast compliance.
 :SilkCircuitContrast
 ```
 
-Checks all highlight groups against WCAG AA standards (4.5:1 ratio) and reports any issues.
+Measures every color the theme renders as text against the current variant's background and reports anything below the WCAG AA ratio of 4.5:1.
 
 ---
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -65,7 +65,7 @@ Show detected plugin integrations.
 :SilkCircuitIntegrations
 ```
 
-Lists all plugins that SilkCircuit has detected and themed.
+Lists all plugins that SilkCircuit has detected.
 
 ---
 
@@ -86,7 +86,6 @@ Verifies:
 - Theme loading status
 - Plugin integrations
 - WCAG contrast compliance
-- Cache status
 
 ---
 

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -201,7 +201,7 @@ Configuration
 - OK Dim inactive: false
 
 Plugin integrations
-- OK 29 integrations available, 5 plugins detected
+- OK 39 integrations available, 5 plugins detected
 - OK Detected: cmp, gitsigns, lualine, telescope, treesitter
 
 User preferences

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -12,66 +12,37 @@ This command verifies your SilkCircuit installation and configuration.
 
 ## Check Categories
 
-### Version Compatibility
+The report is grouped into six sections. A full transcript is at the [bottom of this page](#health-check-output-example).
 
-Verifies Neovim version meets requirements:
+### SilkCircuit
 
-- **Required:** Neovim 0.10.0+
-
-```
-✓ Neovim version: 0.10.0 (OK)
-```
-
-### True Color Support
-
-Checks if your terminal supports 24-bit colors:
-
-```
-✓ True colors enabled ($COLORTERM=truecolor)
-✓ termguicolors is set
-```
+Reports the running Neovim version (0.10.0 or later is required), whether `termguicolors` is on, and whether SilkCircuit is the active colorscheme. A missing `termguicolors` is an error, since every highlight the theme sets is a 24-bit color.
 
 If true colors aren't working:
 
 1. Add `vim.opt.termguicolors = true` to your config
-2. Verify terminal supports true colors
-3. Check `$COLORTERM` environment variable
+2. Verify your terminal supports true colors
+3. Check the `$COLORTERM` environment variable
 
-### Theme Status
+### Configuration
 
-Confirms SilkCircuit is properly loaded:
+Echoes the four settings that change what gets painted: the active variant, `transparent`, `terminal_colors`, and `dim_inactive`.
 
-```
-✓ SilkCircuit theme loaded
-✓ Current variant: neon
-```
+### Plugin integrations
 
-### Plugin Integrations
+Reports how many integrations the theme ships, how many of their plugins it can see on your runtime path, and which ones those are. Detection is for this report only and never gates loading, so an integration you have not installed still has its highlights defined. Any integration you switched off in `setup()` is listed as a warning.
 
-Lists detected plugin integrations:
+### User preferences
 
-```
-✓ telescope.nvim: themed
-✓ neo-tree.nvim: themed
-✓ nvim-cmp: themed
-✓ gitsigns.nvim: themed
-```
+Shows the saved variant and glow setting if `~/.local/share/nvim/silkcircuit_preferences.json` exists, and says so plainly when it doesn't.
 
-### WCAG Compliance
+### WCAG contrast
 
-Validates contrast ratios meet accessibility standards:
+Measures every distinct text color in the active variant against that variant's own background and reports how many clear WCAG AA at 4.5:1. Anything short of the ratio is listed individually as a warning or an error.
 
-```
-✓ All highlight groups meet WCAG AA contrast (4.5:1)
-```
+### Commands
 
-### User Preferences
-
-Shows whether a saved variant or glow setting is overriding the configured defaults:
-
-```
-✓ No saved preferences, using the configured values
-```
+Lists the commands the plugin registered, as a reminder of what is available.
 
 ## Common Issues
 

--- a/docs/reference/highlights.md
+++ b/docs/reference/highlights.md
@@ -14,7 +14,7 @@ Complete reference for SilkCircuit highlight group mappings.
 | `Number`     | Coral      | None         | Numeric values         |
 | `Boolean`    | Pink       | None         | true/false             |
 | `Type`       | Yellow     | None         | Type names             |
-| `Comment`    | Gray       | Italic       | Comments               |
+| `Comment`    | Comment    | Italic       | Comments               |
 | `Operator`   | Foreground | None         | Operators              |
 | `Identifier` | Foreground | None         | Variables              |
 
@@ -39,7 +39,7 @@ Complete reference for SilkCircuit highlight group mappings.
 | `@tag`           | Pink        | HTML/XML tags        |
 | `@attribute`     | Purple      | Attributes           |
 | `@punctuation`   | Foreground  | Punctuation          |
-| `@comment`       | Gray        | Comments             |
+| `@comment`       | Comment     | Comments             |
 
 ## Editor Highlights
 
@@ -157,7 +157,7 @@ Complete reference for SilkCircuit highlight group mappings.
 require("silkcircuit").setup({
   on_highlights = function(hl, colors)
     hl.Function = { fg = colors.cyan, bold = true, italic = true }
-    hl.Comment = { fg = colors.gray, italic = true }
+    hl.Comment = { fg = colors.comment, italic = true }
   end,
 })
 ```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -23,15 +23,15 @@ require("silkcircuit").setup({
 
 ### Configuration Options
 
-| Option            | Type     | Default  | Description                |
-| ----------------- | -------- | -------- | -------------------------- |
-| `variant`         | string   | `"neon"` | Theme variant              |
-| `transparent`     | boolean  | `false`  | Transparent background     |
-| `terminal_colors` | boolean  | `true`   | Configure terminal colors  |
-| `dim_inactive`    | boolean  | `false`  | Dim inactive windows       |
-| `styles`          | table    | `{}`     | Syntax styling options     |
-| `integrations`    | table    | `{}`     | Plugin integrations        |
-| `on_highlights`   | function | `nil`    | Custom highlights callback |
+| Option            | Type     | Default         | Description                |
+| ----------------- | -------- | --------------- | -------------------------- |
+| `variant`         | string   | `"neon"`        | Theme variant              |
+| `transparent`     | boolean  | `false`         | Transparent background     |
+| `terminal_colors` | boolean  | `true`          | Configure terminal colors  |
+| `dim_inactive`    | boolean  | `false`         | Dim inactive windows       |
+| `styles`          | table    | comments italic | Syntax styling options     |
+| `integrations`    | table    | all 39 enabled  | Plugin integrations        |
+| `on_highlights`   | function | `nil`           | Custom highlights callback |
 
 ### Styles Options
 
@@ -133,4 +133,3 @@ lua/silkcircuit/
 | File                                               | Purpose           |
 | -------------------------------------------------- | ----------------- |
 | `~/.local/share/nvim/silkcircuit_preferences.json` | Saved preferences |
-| `~/.cache/nvim/silkcircuit/`                       | Compiled cache    |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -78,7 +78,8 @@ The `colors` table in `on_highlights` includes:
 | `yellow`    | Classes, types         |
 | `green`     | Success, additions     |
 | `red`       | Errors, deletions      |
-| `gray`      | Comments, muted        |
+| `gray`      | Line numbers, glyphs   |
+| `comment`   | Comments (purple)      |
 | `bg`        | Background             |
 | `fg`        | Foreground             |
 

--- a/docs/variants/dawn.md
+++ b/docs/variants/dawn.md
@@ -28,21 +28,24 @@ A beautiful light theme for daytime coding with electric accents.
 
 ### Supporting Colors
 
-| Color | Hex       | Usage                  |
-| ----- | --------- | ---------------------- |
-| Green | `#1d6e46` | Success, git additions |
-| Red   | `#c1272d` | Errors, git deletions  |
-| Blue  | `#1454dc` | Links, info            |
-| Gray  | `#686177` | Comments, muted text   |
+| Color   | Hex       | Usage                         |
+| ------- | --------- | ----------------------------- |
+| Green   | `#1d6e46` | Success, git additions        |
+| Red     | `#c1272d` | Errors, git deletions         |
+| Blue    | `#1454dc` | Links, info                   |
+| Gray    | `#686177` | Line numbers, non-text glyphs |
+| Comment | `#7353a9` | Comments                      |
 
 ### Background Spectrum
 
-| Element      | Hex       | Usage                  |
-| ------------ | --------- | ---------------------- |
-| bg           | `#faf8ff` | Main editor background |
-| bg_dark      | `#f4f0ff` | Sidebar, panels        |
-| bg_highlight | `#f7f4ff` | Popups, highlights     |
-| bg_visual    | `#d4c8f0` | Selection              |
+| Element       | Hex       | Usage                   |
+| ------------- | --------- | ----------------------- |
+| bg            | `#faf8ff` | Main editor background  |
+| bg_highlight  | `#f7f4ff` | Cursorline              |
+| bg_dark       | `#f4f0ff` | Sidebar, panels         |
+| bg_float      | `#e8dffd` | Popups, menus, dividers |
+| bg_statusline | `#ded3f8` | Statusline, tab bar     |
+| bg_visual     | `#d4c8f0` | Selection               |
 
 ## Terminal Colors
 

--- a/docs/variants/glow.md
+++ b/docs/variants/glow.md
@@ -28,12 +28,13 @@ Ultra-dark backgrounds with pure neon colors for maximum contrast.
 
 ### Supporting Colors
 
-| Color | Hex       | Usage                  |
-| ----- | --------- | ---------------------- |
-| Green | `#00ff00` | Success, git additions |
-| Red   | `#ff2244` | Errors, git deletions  |
-| Blue  | `#0099ff` | Links, info            |
-| Gray  | `#818181` | Comments, muted text   |
+| Color   | Hex       | Usage                         |
+| ------- | --------- | ----------------------------- |
+| Green   | `#00ff00` | Success, git additions        |
+| Red     | `#ff2244` | Errors, git deletions         |
+| Blue    | `#0099ff` | Links, info                   |
+| Gray    | `#818181` | Line numbers, non-text glyphs |
+| Comment | `#cc66ff` | Comments                      |
 
 ## Terminal Colors
 

--- a/docs/variants/index.md
+++ b/docs/variants/index.md
@@ -72,5 +72,5 @@ All variants maintain:
 
 - **Semantic consistency**: Keywords are always purple, functions are always cyan
 - **WCAG AA compliance**: 4.5:1 minimum contrast ratios
-- **Plugin compatibility**: Full support for 35+ integrations
+- **Plugin compatibility**: Full support for all 39 integrations
 - **Terminal integration**: Matching ANSI colors

--- a/docs/variants/neon.md
+++ b/docs/variants/neon.md
@@ -32,7 +32,7 @@ The original SilkCircuit experience. Maximum vibrancy and electric energy.
 | ----- | --------- | ---------------------- |
 | Green | `#50fa7b` | Success, git additions |
 | Red   | `#ff6363` | Errors, git deletions  |
-| Blue  | `#82AAFF` | Links, info            |
+| Blue  | `#82aaff` | Links, info            |
 | Gray  | `#768d8d` | Comments, muted text   |
 
 ## Terminal Colors

--- a/docs/variants/neon.md
+++ b/docs/variants/neon.md
@@ -28,12 +28,13 @@ The original SilkCircuit experience. Maximum vibrancy and electric energy.
 
 ### Supporting Colors
 
-| Color | Hex       | Usage                  |
-| ----- | --------- | ---------------------- |
-| Green | `#50fa7b` | Success, git additions |
-| Red   | `#ff6363` | Errors, git deletions  |
-| Blue  | `#82aaff` | Links, info            |
-| Gray  | `#768d8d` | Comments, muted text   |
+| Color   | Hex       | Usage                         |
+| ------- | --------- | ----------------------------- |
+| Green   | `#50fa7b` | Success, git additions        |
+| Red     | `#ff6363` | Errors, git deletions         |
+| Blue    | `#82aaff` | Links, info                   |
+| Gray    | `#768d8d` | Line numbers, non-text glyphs |
+| Comment | `#9580ff` | Comments                      |
 
 ## Terminal Colors
 

--- a/docs/variants/soft.md
+++ b/docs/variants/soft.md
@@ -28,12 +28,13 @@ Gentle colors for marathon coding sessions and late-night work.
 
 ### Supporting Colors
 
-| Color | Hex       | Usage                  |
-| ----- | --------- | ---------------------- |
-| Green | `#66ff99` | Success, git additions |
-| Red   | `#ff6677` | Errors, git deletions  |
-| Blue  | `#92aaff` | Links, info            |
-| Gray  | `#7e9494` | Comments, muted text   |
+| Color   | Hex       | Usage                         |
+| ------- | --------- | ----------------------------- |
+| Green   | `#66ff99` | Success, git additions        |
+| Red     | `#ff6677` | Errors, git deletions         |
+| Blue    | `#92aaff` | Links, info                   |
+| Gray    | `#7e9494` | Line numbers, non-text glyphs |
+| Comment | `#b199ff` | Comments                      |
 
 ## Terminal Colors
 

--- a/docs/variants/vibrant.md
+++ b/docs/variants/vibrant.md
@@ -28,12 +28,13 @@ Balanced energy with slightly toned-down saturation for everyday coding.
 
 ### Supporting Colors
 
-| Color | Hex       | Usage                  |
-| ----- | --------- | ---------------------- |
-| Green | `#00ff66` | Success, git additions |
-| Red   | `#ff3366` | Errors, git deletions  |
-| Blue  | `#6699ff` | Links, info            |
-| Gray  | `#728989` | Comments, muted text   |
+| Color   | Hex       | Usage                         |
+| ------- | --------- | ----------------------------- |
+| Green   | `#00ff66` | Success, git additions        |
+| Red     | `#ff3366` | Errors, git deletions         |
+| Blue    | `#6699ff` | Links, info                   |
+| Gray    | `#728989` | Line numbers, non-text glyphs |
+| Comment | `#b366ff` | Comments                      |
 
 ## Terminal Colors
 


### PR DESCRIPTION
# 💜 Catch the prose up with v2

> Documentation only. No file under `lua/`, `tests/`, `extras/` or `docs/extras/` is touched, so nothing the theme renders changes.

## 💡 What this is

The docs described a version of SilkCircuit that stopped existing a couple of release cycles ago. They promised a bytecode cache to regenerate, told users that integrations wait for plugin detection before theming anything, counted 29 or 35+ integrations against a registry that holds 39, and printed a neon palette whose background, foreground, string colour and number colour appear nowhere in `variants.lua`. This rewrites those claims against the code, one file:line at a time, with every number and every hex read out of the source rather than remembered.

## 🤔 Why it matters

Two of the errors were actively misleading rather than merely stale. A contributor reading `AGENTS.md` would have wired a new integration into a detection path that does not gate anything, and a user reading `docs/reference/health.md` would have compared their real `:checkhealth` output against a transcript that was invented: there is no `$COLORTERM` check, no per-plugin "themed" line, and the contrast section reports text colours rather than "all highlight groups". The rest was drift, but drift that compounds, since each stale count gave the next writer permission to copy it.

## 🎯 The anchor

One property carries the whole change: **every claim in these files now traces to a line in `lua/`**. Counts come from the registry in `integrations/init.lua` (39 entries) and the target modules in `lua/silkcircuit/extra/` (30, excluding `init`, `docs` and `palette`). Colours come from `variants.lua`. Behaviour comes from `health.lua`, `config.lua` and `doc/silkcircuit.txt`. If a reviewer finds a sentence that does not, that is the bug.

## 🛠️ What changed, by commit

**1. `docs: retire the cache story and the auto-detect framing`** removes the compiled-cache tile from the docs home page, the `~/.cache/nvim/silkcircuit/` row from the User Files table and the "Cache status" bullet from the checkhealth list. The README and the configuration guide now say that all 39 integrations are defined up front whether or not the plugin is installed, and that `integrations.<name> = false` is the way to switch one off. The health page's six invented per-category output blocks are replaced by a sentence per real section, with the transcript already at the bottom of the page as the single example. The `styles` and `integrations` defaults in the reference table now show what `config.lua` actually ships instead of `{}`.

**2. `docs: correct the counts and the palette table`** takes 25+, 29, 35+ and "20+ tools" to 39 and 30 across the README, `doc/silkcircuit.txt`, the docs site and the VitePress `description` and `og:description`. The README colour table is regenerated from the neon block of `variants.lua`: background `#12101a` and foreground `#f8f8f2` (it listed `#0a0a0f` and `#e0e0e0`, which exist in no variant), strings to `pink_soft` `#ff99ff` (it had `#ff79c6`, which the theme uses only for `diff_change`), numbers to `coral` `#ff6ac1` (it had `#ffb86c`, absent from the palette entirely), plus rows for types and errors. The platform table gains the five shipped targets it omitted: Helix, foot, iTerm2, WezTerm and Zellij.

**3. `docs: give vibrant its own column and fix role labels`** splits vibrant out of the merged "Neon/Vibrant" rows it never belonged in, since the two share none of their green, yellow or red (`#00ff66` / `#ffcc00` / `#ff3366` against `#50fa7b` / `#f1fa8c` / `#ff6363`). The other repeated error was gray: gray carries line numbers and non-text glyphs, while comments are `purple_muted`, which is why they read lavender on screen. Every table that called gray the comment colour now says what it is, and the five variant pages gained a Comment row with the purple each one uses. Dawn's background table gains the missing `bg_float` and `bg_statusline` rows.

**4. `docs(agents): teach the v2 loading model`** rewrites the third core principle around passive loading, retitles `util.lua` (which has no compilation in it) and `integrations/init.lua`, and gives the new-integration recipe its real three steps: the module, the registry entry, and the key in the `config.lua` defaults.

## 🧪 Validation

- `make check` → **96 run, 96 passed, 0 failed**, with selene, StyLua, ruff and prettier over `**/*.{json,jsonc,yaml,yml,md}` all clean.
- `cd docs && npm ci && npm run docs:build` → vitepress 1.6.4, client and server bundles built, all pages rendered, **build complete in 1.91s**, no warnings.
- Every hex in every changed file was checked against the five variants' colour tables by script: **0 unknown**. The one non-palette hex in the diff is a pre-existing `#888888` in a user-override example on the health page, which is arbitrary by design.
- `grep -rn 'bytecode\|Compiled cache\|auto-detect\|Auto-detect\|auto_detect'` over `README.md`, `AGENTS.md` and `docs/` → **no matches**. The deliberate deprecation note at `doc/silkcircuit.txt:240` and the no-op `auto_detect` key in `config.lua` are both outside that sweep and both stay.
- `grep -rn '25+\|35+\|20+ tools\|29 plugin\|29 integrations'` over `README.md`, `AGENTS.md`, `docs/` and `doc/` → one hit, "Chrome DevTools 2025+" on an untouched extras page.
- The counts were derived, not assumed: 39 `name =` entries in the registry, 30 modules in `lua/silkcircuit/extra/` after excluding `init`, `docs` and `palette`.
- `:checkhealth`'s contrast numbers were run rather than copied. `validate_theme_contrast` on neon returns `checked=19 issues=0`, which is what the page now claims.
- `nvim --headless -c 'helptags doc'` left `doc/tags` byte-identical, since 29 and 39 are the same width and no help layout shifted.

⚠️ Prettier flags `docs/.vitepress/config.ts`, and it flagged the same file on `main` before this branch existed. TypeScript sits outside the repo's prettier glob in the Makefile deliberately, so reformatting it here would be an unrelated diff.

## 🔍 What reviewers should focus on

- **The accessibility table in `docs/design/accessibility.md`.** The audit that drove this branch called for dropping the "UI elements 3:1" row as an unverified claim. Reading `tests/spec/contrast_spec.lua` says otherwise: it gates a `chrome` tier at 3:1 over borders, gutters, indent guides and the ANSI normals, so the row is kept and marked as gated. Only the Graphics row is now labelled a design target.
- **The README palette table's new framing line.** It says these are the neon variant's values, which the heading never said before. Worth a look if you would rather it stayed unqualified.
- **The `colors.gray` to `colors.comment` swap** in the three `on_highlights` examples. `colors.comment` is a real key, derived in `variants.lua`, but the examples now demonstrate the default rather than an override.
- **The Multiplexers row in the README platform table.** tmux moved out of System to sit with Zellij. Say the word if you would rather it stayed put.

Intentionally out of scope: the variant intensity percentages in the README and the guide, which match the description strings in `variants.lua` and are a narrative choice rather than a measurement, and the tone of `docs/design/typography.md` and `best-practices.md` beyond removing one stray line from a CSS block that was never CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtDjeCyHdLUr9R4XnnFVx9
