### PR TITLE
Repair statusline escaping and drop the deprecated LSP fallback in the AstroNvim lualine extra

### DIFF
--- a/extras/astronvim/plugins/lualine-max-effect.lua
+++ b/extras/astronvim/plugins/lualine-max-effect.lua
@@ -13,10 +13,7 @@ return {
       local visual_block_mode = string.char(22)
       local select_block_mode = string.char(19)
       local function get_current_clients()
-        if vim.lsp.get_clients then
-          return vim.lsp.get_clients({ bufnr = 0 })
-        end
-        return vim.lsp.get_active_clients()
+        return vim.lsp.get_clients({ bufnr = 0 })
       end
 
       -- Custom components with enhanced visual features
@@ -109,7 +106,9 @@ return {
             local current = vim.fn.line(".")
             local total = vim.fn.line("$")
             local percent = math.floor(current / total * 100)
-            return string.format("%3d%% %d/%d", percent, current, total)
+            -- statusline-escape the literal percent: lualine only escapes
+            -- built-in components, and a raw "% " is an invalid stl item
+            return string.format("%3d%%%% %d/%d", percent, current, total)
           end,
           icon = "",
           color = { fg = silkcircuit_colors.purple_muted },


### PR DESCRIPTION
> The AstroNvim extra at `extras/astronvim/plugins/lualine-max-effect.lua`, which the installer copies verbatim into dotfiles.

## 💡 What this is

Two fixes to the custom lualine statusline extra, found while migrating the dotfiles Neovim config to AstroNvim v6.

## 🛠️ What changed

1. **Statusline escaping (the real bug).** The progress component returned `"45% 1/233"` raw. lualine stl-escapes only its built-in components, never custom function components, so the literal `% ` reached `'statusline'` as an invalid item and threw `E539: Illegal character` on refresh. The component now emits `%%` so the rendered line shows a single percent sign.
2. **Deprecated LSP fallback.** `get_current_clients` still fell back to `vim.lsp.get_active_clients()`, which only tripped the deprecation diagnostic; AstroNvim v6 requires Neovim 0.11+ where `vim.lsp.get_clients` always exists. The fallback is gone.

## 🧪 Validation

- Reproduced the E539 on a live AstroNvim v6.0 + Neovim 0.12.5 session before the fix; after it, `nvim_eval_statusline` renders the escaped percent and the statusline refreshes cleanly (verified independently by a Codex review pass on the dotfiles branch).
- `stylua --check` clean under this repo's config.
- The patched extra is byte-identical to the copy tracked in hyperb1iss/dotfiles on `nova/astronvim-v6`, keeping the installer's safe_copy refresh a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019md4TwnDo6j1mweRX2L38p