### PR TITLE
ci(release): pin git-iris to Opus 5 and attach artifacts first

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Only runs on the push that release-please tagged.
+  # Only runs on the push that release-please tagged. Artifacts attach
+  # before anything that can fail on a third party, so a marketplace or
+  # LLM hiccup never leaves the release without its downloads.
   publish:
     name: » Publish
     needs: release-please
@@ -52,6 +54,41 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: → Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: → Package the extension
+        run: make vscode-package
+
+      - name: → Package the Chrome themes
+        run: make chrome-package
+
+      - name: → Attach artifacts to the release
+        run: |
+          gh release upload "$TAG" \
+            extras/vscode/*.vsix \
+            silkcircuit-chrome-*.zip \
+            --clobber
+
+      - name: → Publish to the VS Code Marketplace
+        if: env.VSCE_PAT != ''
+        run: make vscode-publish-vsce
+
+      - name: → Publish to Open VSX
+        if: env.OVSX_PAT != ''
+        run: make vscode-publish-ovsx
+
+      - name: → Note any skipped publish
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "! VSCE_PAT is not set, skipped the VS Code Marketplace"
+          fi
+          if [ -z "$OVSX_PAT" ]; then
+            echo "! OVSX_PAT is not set, skipped Open VSX"
+          fi
+
       - name: → Find the previous release tag
         if: env.IRIS_KEY != ''
         id: prev
@@ -70,6 +107,7 @@ jobs:
           to: ${{ env.TAG }}
           version-name: ${{ env.TAG }}
           provider: anthropic
+          model: claude-opus-5
           api-key: ${{ env.IRIS_KEY }}
           output-file: RELEASE_NOTES.md
           custom-instructions: >-
@@ -91,38 +129,3 @@ jobs:
       - name: → Put the styled notes on the release
         if: env.IRIS_KEY != ''
         run: gh release edit "$TAG" --notes-file RELEASE_NOTES.md
-
-      - name: → Setup Node
-        uses: actions/setup-node@v7
-        with:
-          node-version: 24
-
-      - name: → Package the extension
-        run: make vscode-package
-
-      - name: → Package the Chrome themes
-        run: make chrome-package
-
-      - name: → Publish to the VS Code Marketplace
-        if: env.VSCE_PAT != ''
-        run: make vscode-publish-vsce
-
-      - name: → Publish to Open VSX
-        if: env.OVSX_PAT != ''
-        run: make vscode-publish-ovsx
-
-      - name: → Note any skipped publish
-        run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "! VSCE_PAT is not set, skipped the VS Code Marketplace"
-          fi
-          if [ -z "$OVSX_PAT" ]; then
-            echo "! OVSX_PAT is not set, skipped Open VSX"
-          fi
-
-      - name: → Attach artifacts to the release
-        run: |
-          gh release upload "$TAG" \
-            extras/vscode/*.vsix \
-            silkcircuit-chrome-*.zip \
-            --clobber


### PR DESCRIPTION
# ⚡ Opus 5 release notes, after the downloads land

> One commit against `.github/workflows/release.yml`. Lands before the 2.0.0 release PR (`#4`) merges so the first tagged release runs the corrected publish job.

## 💡 What this is

The publish job already styles release notes with git-iris, but it never said which model, and git-iris 2.1.0 defaults Anthropic to `claude-opus-4-6`. This pins `claude-opus-5` explicitly, so the notes come from the model we chose rather than whatever the pinned action version ships.

It also reorders the job so the release has its downloads before anything that depends on a third party runs. Packaging and the artifact upload come first, then the marketplace publishes, then the styled notes.

## 🤔 Why we need it & what it replaces

The old order ran the LLM call second, straight after checkout, with no `continue-on-error`. A flaky API call would fail the job after release-please had already tagged and created the release, but before the vsix and Chrome zips attached. A rerun cannot recover that: on the second pass release-please reports no new release, so the publish job never enters. The release would sit there with changelog notes and no downloads until someone hand-uploaded them.

Nothing about what gets published changes. The same artifacts attach, the same marketplaces are skipped while `VSCE_PAT` and `OVSX_PAT` are unset, and the notes step still runs only when `ANTHROPIC_API_KEY` exists (it does now, as a repo secret).

## 🎯 The anchor

Anchor on one property: every step that can fail on a third party runs after `gh release upload` has attached the artifacts. A marketplace or LLM hiccup fails the job visibly, but the release already has its downloads.

## 🛠️ How it works

The publish job now runs in this order:

1. Checkout, then Node 24.
2. `make vscode-package` and `make chrome-package`.
3. `gh release upload` with the vsix and the five Chrome zips.
4. VS Code Marketplace and Open VSX publishes, each still gated on its PAT.
5. The skipped-publish note.
6. The previous-tag lookup, the git-iris `release-notes` step with `model: claude-opus-5`, and `gh release edit` to replace the release-please changelog with the styled notes.

The git-iris action accepts a `model` input and passes it through as `--model` with no allowlist, and its Anthropic path sends no temperature or thinking budget, so the Opus 5 request shape is clean.

## 🧪 Validation

- `ruby -ryaml` parses the workflow, 11 publish steps in the new order.
- `make fmt-check` is clean (prettier covers the yaml).
- The pre-commit hooks passed on the commit: prettier, check yaml, trailing whitespace, end of files, merge conflicts.
- `make vscode-package` and `make chrome-package` build locally on this tree (a 1.0.2 vsix plus five zips), so the first two real steps are exercised.
- `gh secret list` shows `ANTHROPIC_API_KEY` on the repo as of today, so the notes steps will run on the 2.0.0 release.

⚠️ The publish job itself only runs on a tagged release push, so its first end-to-end run is v2.0.0. Artifacts attach before the notes step, which is the point of the reorder.

## 🔍 What reviewers should focus on

- The step order in `publish`, and whether attaching artifacts before the marketplace publishes is the failure mode you want (a failed vsce publish now leaves the vsix on the release).
- The `model: claude-opus-5` input on the git-iris step.

## 📌 Follow-ups (deliberate non-fixes)

- The repo has no tags at all, so the previous-tag lookup falls through to the root commit and git-iris summarizes the full 284-commit history for v2.0.0. The release-please changelog already spans the same range, so the two agree. The `v1.0.2...v2.0.0` compare link in the changelog will 404 for the same reason; a `v1.0.2` tag on the commit that introduced that version (`d9cf7a5`) would fix both, and pushing a tag is Bliss's call.
- `VSCE_PAT` and `OVSX_PAT` are still unset, so the marketplace publishes skip until those secrets exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUfbfb9f2i7oHfRNvFr4sM
